### PR TITLE
Update PolygonROI poly_mask()

### DIFF
--- a/xicam/gui/patches/PyQtGraph.py
+++ b/xicam/gui/patches/PyQtGraph.py
@@ -29,7 +29,7 @@ from pyqtgraph.parametertree import Parameter, ParameterItem, registerParameterT
 from pyqtgraph.parametertree import parameterTypes
 from pyqtgraph.widgets.SpinBox import SpinBox
 from pyqtgraph.widgets.ColorButton import ColorButton
-from pyqtgraph import ImageView
+from pyqtgraph import ImageView, ROI, PolyLineROI
 import numpy as np
 from qtpy.QtCore import QSize
 from qtpy.QtGui import QBrush, QPalette
@@ -60,6 +60,40 @@ class ImageView(ImageView):
 
 
 pyqtgraph.__dict__['ImageView'] = ImageView
+
+
+class PolyLineROI(PolyLineROI):
+    def getArrayRegion(self, data, img, axes=(0, 1), **kwds):
+        """
+        Return the result of ROI.getArrayRegion(), masked by the shape of the
+        ROI. Values outside the ROI shape are set to 0.
+        """
+        br = self.boundingRect()
+        if br.width() > 1000:
+            raise Exception()
+        sliced = ROI.getArrayRegion(self, data, img, axes=axes, fromBoundingRect=True, **kwds)
+        if kwds.get('returnMappedCoords'):
+            sliced, mapped = sliced
+
+        if img.axisOrder == 'col-major':
+            mask = self.renderShapeMask(sliced.shape[axes[0]], sliced.shape[axes[1]])
+        else:
+            mask = self.renderShapeMask(sliced.shape[axes[1]], sliced.shape[axes[0]])
+            mask = mask.T
+
+        # reshape mask to ensure it is applied to the correct data axes
+        shape = [1] * data.ndim
+        shape[axes[0]] = sliced.shape[axes[0]]
+        shape[axes[1]] = sliced.shape[axes[1]]
+        mask = mask.reshape(shape)
+
+        if kwds.get('returnMappedCoords'):
+            return sliced * mask, mapped
+        else:
+            return sliced * mask
+
+
+pyqtgraph.__dict__['PolyLineROI'] = PolyLineROI
 
 
 class SafeImageView(ImageView):

--- a/xicam/gui/widgets/imageviewmixins.py
+++ b/xicam/gui/widgets/imageviewmixins.py
@@ -349,6 +349,20 @@ class PolygonROI(ImageView):
         floorX = np.floor(mapped[0]).astype(int)
         floorY = np.floor(mapped[1]).astype(int)
 
+        # TODO TEMP
+        from matplotlib import pyplot as plt
+
+        plt.figure('image (origin=lower)')
+        plt.imshow(self.imageItem.image, origin='lower')
+
+        plt.figure('initial result (origin=lower)')
+        plt.imshow(result, origin='lower')
+        # plt.figure('floor(mapped[0]')
+        # plt.imshow(floorX)
+        # plt.figure('floor(mapped[1]')
+        # plt.imshow(floorY)
+        # END TODO TEMP
+
         # Return empty mask if ROI bounding box does not intersect image bounding box
         resultRect = QRectF(QPointF(np.min(floorX), np.min(floorY)), QPointF(np.max(floorX), np.max(floorY)))
         if not self._intersectsImage(resultRect):
@@ -392,11 +406,23 @@ class PolygonROI(ImageView):
         # assert(y_after_offset - y_before_offset + 1 == height)
         # assert(x_after_offset - x_before_offset + 1 == width)
 
-        bounding_box = np.pad(result, ((xBeforePadding, xAfterPadding), (yBeforePadding, yAfterPadding)), 'constant')
+        bounding_box = np.pad(result, ((xAfterPadding, xBeforePadding), (yAfterPadding, yBeforePadding)), 'constant')
+
+        plt.figure('bounding_box, origin="lower"')
+        plt.imshow(bounding_box, origin='lower')
 
         # Trim off mask that does not intersect with the image
-        trimmed = bounding_box[int(abs(xBefore)):width - xBefore, int(abs(yBefore)):height - yBefore]
+        rowSliceLower = int(abs(xBefore))
+        rowSliceUpper = width - xBefore
+        colSliceLower = int(abs(yBefore))
+        colSliceUpper = height - yBefore
+        trimmed = bounding_box[rowSliceLower:rowSliceUpper, colSliceLower:colSliceUpper]
         # trimmed[roiMinX:roiMaxX+1, roiMinY:roiMaxY+1]
+        # TODO TEMP
+        plt.figure(f'trimmed, origin="lower"; slice -- {rowSliceLower}:{rowSliceUpper}, {colSliceLower}:{colSliceUpper}')
+        plt.imshow(trimmed, origin='lower')
+        plt.show()
+        # END TODO TEMP
         return trimmed
 
 


### PR DESCRIPTION
<details>
<summary>PolygonROI</summary>
<ul>
<li>update PolygonROI documentation</li>
<li><code>poly_mask()</code> now returns a mask that is padded and trimmed into image space, and its shape matches the image item's shape</li>
<ul>
<li>previous behavior returned a mask array for the polygon, then stretched it into the image's shape</li>
<li>unused `shape` argument removed</li>
</ul>
</ul>
</details>

<details>
<summary>PyQtGraph PolygonROI patch</summary>
<ul>
<li>Patched PolygonROI to use <code>returnMappedCoords</code> kwarg</li>
</ul>
</details>
