### PR TITLE
Update from master, add mixin to for avoiding overflow in getHistogram

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
     # simple. Or you can use find_packages().
     packages=[
         "xicam.gui",
+        "xicam.gui.bluesky",
         "xicam.gui.cammart",
         "xicam.gui.settings",
         "xicam.gui.static",
@@ -81,7 +82,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=["qtpy", "pathlib", "pyqtgraph", "qdarkstyle", "qtmodern", "qtconsole", "xicam.plugins", "xicam.core"]
+    install_requires=["qtpy", "pathlib", "pyqtgraph", "qdarkstyle", "qtmodern", "qtconsole", "xicam.plugins", "xicam.core", "bluesky-browser"]
     + pyqt,
     setup_requires=[],
     # List additional groups of dependencies here (e.g. development
@@ -106,7 +107,8 @@ setup(
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # pip to create the appropriate form of executable for the target platform.
     entry_points={'xicam.plugins.SettingsPlugin': ['cammart = xicam.gui.cammart:CamMartSettingsPlugin',
-                                                   'venvs = xicam.gui.cammart.venvs:VenvsSettingsPlugin']},
+                                                   'venvs = xicam.gui.cammart.venvs:VenvsSettingsPlugin'],
+                  'xicam.plugins.CatalogPlugin': ['databroker_catalog_plugin = xicam.gui.bluesky.databroker_catalog_plugin:DatabrokerCatalogPlugin']},
     ext_modules=[],
     include_package_data=True,
 )

--- a/xicam/gui/bluesky/central.py
+++ b/xicam/gui/bluesky/central.py
@@ -1,0 +1,82 @@
+"""
+Provides a central widget that contains much of what the blueskybrowser.
+Might go away eventually, but needed to prevent the CentralWdiget from
+trying to setup a menu.
+"""
+
+import time
+
+from bluesky_browser.frameworks.qt.search import SearchWidget, SearchState
+# from bluesky_browser.frameworks.qt.summary import SummaryWidget
+from xicam.gui.bluesky.summary import SummaryWidget
+
+from qtpy.QtCore import QDateTime, Qt
+from qtpy.QtWidgets import (
+    QWidget,
+    QHBoxLayout,
+    QSplitter)
+
+
+class CentralWidget(QWidget):
+    """
+    Encapsulates all widgets and models. Connect signals on __init__.
+    """
+    def __init__(self, *args,
+                 catalog, menuBar,
+                 zmq_address=None, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Define models.
+        search_state = SearchState(
+            catalog=catalog)
+        self.search_model = search_state.search_results_model
+        # Define widgets.
+        self.search_widget = SearchWidget()
+        self.summary_widget = SummaryWidget()
+
+        left_pane = QSplitter(Qt.Vertical)
+        left_pane.addWidget(self.search_widget)
+        left_pane.addWidget(self.summary_widget)
+
+        layout = QHBoxLayout()
+        splitter = QSplitter(Qt.Horizontal)
+        layout.addWidget(splitter)
+        splitter.addWidget(left_pane)
+
+        self.setLayout(layout)
+
+        def show_double_clicked_entry(index):
+            search_state.search_results_model.emit_open_entries(None, [index])
+
+        # Set models, connect signals, and set initial values.
+        now = time.time()
+        ONE_WEEK = 60 * 60 * 24 * 7
+        self.search_widget.search_results_widget.setModel(
+            search_state.search_results_model)
+        self.search_widget.search_input_widget.search_bar.textChanged.connect(
+            search_state.search_results_model.on_search_text_changed)
+        self.search_widget.catalog_selection_widget.catalog_list.setModel(
+            search_state.catalog_selection_model)
+        self.search_widget.search_input_widget.until_widget.dateTimeChanged.connect(
+            search_state.search_results_model.on_until_time_changed)
+        self.search_widget.search_input_widget.until_widget.setDateTime(
+            QDateTime.fromSecsSinceEpoch(now + ONE_WEEK))
+        self.search_widget.search_input_widget.since_widget.dateTimeChanged.connect(
+            search_state.search_results_model.on_since_time_changed)
+        self.search_widget.search_input_widget.since_widget.setDateTime(
+            QDateTime.fromSecsSinceEpoch(now - ONE_WEEK))
+        self.search_widget.catalog_selection_widget.catalog_list.currentIndexChanged.connect(
+            search_state.set_selected_catalog)
+        self.search_widget.search_results_widget.selectionModel().selectionChanged.connect(
+            search_state.search_results_model.emit_selected_result)
+        self.search_widget.search_results_widget.doubleClicked.connect(
+            show_double_clicked_entry)
+        search_state.search_results_model.selected_result.connect(
+            self.summary_widget.set_entries)
+        search_state.search_results_model.valid_custom_query.connect(
+            self.search_widget.search_input_widget.mark_custom_query)
+        search_state.enabled = True
+        search_state.search()
+
+
+

--- a/xicam/gui/bluesky/databroker_catalog_plugin.py
+++ b/xicam/gui/bluesky/databroker_catalog_plugin.py
@@ -1,0 +1,116 @@
+"""
+Catalog Plugin for browsing pre-configured databroker catalogs
+"""
+from databroker import MergedCatalog
+from xicam.plugins.catalogplugin import CatalogPlugin
+from xicam.gui.widgets.dataresourcebrowser import QListView
+from databroker.core import BlueskyRun
+from databroker.v2 import Broker
+from intake.catalog import Catalog
+from intake.catalog.base import RemoteCatalog
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import QWidget, QVBoxLayout
+import logging
+
+from xicam.gui.bluesky.central import CentralWidget
+
+# from bluesky_browser.frameworks.qt.main import CentralWidget
+
+logger = logging.getLogger('BlueskyPlugin')
+
+
+class SearchingCatalogController(QWidget):
+    """
+    Displays code that lets a user select from a root catalog.
+
+
+    """
+
+    sigOpen = Signal(object)
+    sigSelectedRun = Signal([list])
+    sigPreview = Signal(BlueskyRun)
+    catalog = None
+
+    def __init__(self, root_catalog):
+        """
+          The root catalog can be a single catalog or a collection of catalogs.
+            Check out https://nsls-ii.github.io/databroker/v2/user/index.htmll#find-a-catalog. This
+            class is intended to guide a user to select a catalog from the list in root catalog,
+            then inspect and possibly open a selected run catalog.
+
+        :param root_catalog: top level catalog that might contain more catalogs
+        """
+        super(SearchingCatalogController, self).__init__()
+
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.centralWidget = CentralWidget(menuBar=None, catalog=root_catalog)
+
+        def emit_opened_catalogs(name, my_list):
+            """Emit each selected and opened catalog to sigOpen"""
+            [self.sigOpen.emit(item) for item in my_list]
+
+        # connect the open_entries in the search model to sigOpen
+        self.centralWidget.search_model.open_entries.connect(emit_opened_catalogs)
+        self.centralWidget.summary_widget.open.connect(emit_opened_catalogs)
+        layout.addWidget(self.centralWidget)
+
+
+class DatabrokerCatalogPlugin(CatalogPlugin):
+    """
+    Plugin for providing a user interface for browsing and selecting databroker
+    catalogs. Users can select one or more catalogs in a list, which will signal
+    to xi-cam sigOpen.
+    """
+
+    # set name here so that it appears in the catalog dropdown
+    name = 'Bluesky Databroker'
+
+    def __new__(cls):
+        # importing catalog gives us #a catalog of pre-configured catalogs YAML files
+        # locations by default might look something like:
+        #  'USER_HOME/.local/share/intake', 'PYTHON_ENV/share/intake'
+        from databroker import catalog
+        # normalizedCatalogs = []
+        # assemble_catalogs(normalizedCatalogs, catalog)
+
+        # set name again because CatalogPlugins also inherit from Catalog, and that by
+        # default not have a name
+        # mergedCatalog = MergedCatalog(normalizedCatalogs)
+        # mergedCatalog.controller = SearchingCatalogController(mergedCatalog)
+        # mergedCatalog.view = QListView()
+        # mergedCatalog.name = 'Bluesky Databroker'
+        # return mergedCatalog
+
+        '''
+        Hard-coded to read from a yaml source named 'intake_server' for testing.
+        
+        '''
+        catalog.controller = SearchingCatalogController(catalog)
+        catalog.view = QListView()
+        catalog.name = 'Bluesky Databroker'
+        return catalog
+
+# def assemble_catalogs(normalizedCatalogs, parentCatalog):
+#     '''
+#      create a dict of only top level catalogs...parents of BlueskyRun
+#     :param normalizedCatalog:
+#     :param databrokerCatalogs:
+#     :return:
+#     '''
+#
+#     for catalogName in parentCatalog:
+#         catalogEntry = parentCatalog[catalogName]
+#         catalog = catalogEntry.get()
+#         if isinstance(catalog, Broker):
+#             # this test fails because when coming from intake,
+#             # the parent of BlueSkyRuns is a RemoteCatalog, not a Broker
+#             normalizedCatalogs.append(catalog)
+#             continue
+#         elif isinstance(catalog, Catalog):
+#             assemble_catalogs(normalizedCatalogs, catalog)
+#         else:
+#             continue
+

--- a/xicam/gui/bluesky/summary.py
+++ b/xicam/gui/bluesky/summary.py
@@ -1,0 +1,81 @@
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QInputDialog,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+    )
+
+
+class SummaryWidget(QWidget):
+    open = Signal([str, list])
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uid_label = QLabel()
+        self.open_individually_button = QPushButton('Open')
+        self.open_individually_button.setEnabled(False)
+        self.open_individually_button.clicked.connect(self._open_individually)
+        self.copy_uid_button = QPushButton('Copy UID to Clipboard')
+        self.copy_uid_button.setEnabled(False)
+        self.copy_uid_button.clicked.connect(self._copy_uid)
+        self.streams = QLabel()
+        self.entries = []
+
+        uid_layout = QHBoxLayout()
+        uid_layout.addWidget(self.uid_label)
+        uid_layout.addWidget(self.copy_uid_button)
+        layout = QVBoxLayout()
+        layout.addWidget(self.open_individually_button)
+        layout.addLayout(uid_layout)
+        layout.addWidget(self.streams)
+        self.setLayout(layout)
+
+        self._tab_titles = ()
+
+    def cache_tab_titles(self, titles):
+        self._tab_titles = titles
+
+    def _copy_uid(self):
+        QApplication.clipboard().setText(self.uid)
+
+    def _open_individually(self):
+        for entry in self.entries:
+            self.open.emit(None, [entry])
+
+
+    def set_entries(self, entries):
+        self.entries.clear()
+        self.entries.extend(entries)
+        if not entries:
+            self.uid_label.setText('')
+            self.streams.setText('')
+            self.copy_uid_button.setEnabled(False)
+            self.open_individually_button.setEnabled(False)
+        elif len(entries) == 1:
+            entry, = entries
+            run = entry()
+            self.uid = run.metadata['start']['uid']
+            self.uid_label.setText(self.uid[:8])
+            self.copy_uid_button.setEnabled(True)
+            self.open_individually_button.setEnabled(True)
+            self.open_individually_button.setText('Open')
+            num_events = (run.metadata['stop'] or {}).get('num_events')
+            if num_events:
+                self.streams.setText(
+                    'Streams:\n' + ('\n'.join(f'{k} ({v} Events)' for k, v in num_events.items())))
+            else:
+                # Either the RunStop document has not been emitted yet or was never
+                # emitted due to critical failure or this is an old document stream
+                # from before 'num_events' was added to the schema. Get the list of
+                # stream names another way, and omit the Event count.
+                self.streams.setText('Streams:\n' + ('\n'.join(list(run))))
+        else:
+            self.uid_label.setText('(Multiple Selected)')
+            self.streams.setText('')
+            self.copy_uid_button.setEnabled(False)
+            self.open_individually_button.setText('Open individually')
+            self.open_individually_button.setEnabled(True)

--- a/xicam/gui/tests/test_catalog.py
+++ b/xicam/gui/tests/test_catalog.py
@@ -1,7 +1,7 @@
 from qtpy.QtWidgets import QLabel
 from xicam.plugins import GUIPlugin, GUILayout
 from xicam.gui.widgets.dynimageview import DynImageView
-from xicam.gui.widgets.imageviewmixins import CatalogView
+from xicam.gui.widgets.imageviewmixins import XArrayView
 from xicam.core.data import MetaXArray
 
 
@@ -9,7 +9,7 @@ class TestPlugin(GUIPlugin):
     name = 'catalogtest'
 
     def __init__(self):
-        self.imageview = CatalogView()
+        self.imageview = XArrayView()
 
         self.stages = {'Stage 1': GUILayout(self.imageview), }
 

--- a/xicam/gui/widgets/imageviewmixins.py
+++ b/xicam/gui/widgets/imageviewmixins.py
@@ -445,7 +445,7 @@ class PolygonROI(ImageView):
             offsetX = abs(minX)
         if minY < 0:
             offsetY = abs(minY)
-        trimmed = boundingBox[abs(offsetY) : abs(offsetY) + height, abs(offsetX) : abs(offsetX) + width]
+        trimmed = boundingBox[abs(offsetY): abs(offsetY) + height, abs(offsetX): abs(offsetX) + width]
 
         # Reorient the trimmed mask array
         trimmed = trimmed[::-1, ::-1]
@@ -486,6 +486,16 @@ import collections
 from pyqtgraph import functions as fn
 from pyqtgraph import debug
 from pyqtgraph import Point
+
+
+class ComposableItemImageView(ImageView):
+    """
+    Used to compose together different image view mixins that may use different ItemImage subclasses.
+    See LogScaleIntensity, LogScaleImageItem, ImageViewHistogramOverflowFIx, ImageItemHistorgramOverflowFix.
+    Note that any imageItem named argument passed into the ImageView mixins above will discard the item and instead
+    create a composition of imageItem_bases with their respective ImageItem class.
+    """
+    imageItem_bases = tuple()
 
 
 class LogScaleImageItem(ImageItem):
@@ -546,7 +556,8 @@ class LogScaleImageItem(ImageItem):
                 else:
                     lutdtype = np.min_scalar_type(lut.shape[0] - 1)
                     efflut = fn.rescaleData(
-                        ind, scale=(lut.shape[0] - 1) / levdiff, offset=minlev, dtype=lutdtype, clip=(0, lut.shape[0] - 1)
+                        ind, scale=(lut.shape[0] - 1) / levdiff, offset=minlev, dtype=lutdtype,
+                        clip=(0, lut.shape[0] - 1)
                     )
                     efflut = lut[efflut]
 
@@ -569,13 +580,16 @@ class LogScaleImageItem(ImageItem):
         self.qimage = fn.makeQImage(argb, alpha, transpose=False)
 
 
-class LogScaleIntensity(ImageView):
-    def __init__(self, *args, **kwargs):
-        if kwargs.get("imageItem") and not isinstance(kwargs.get("imageItem"), LogScaleImageItem):
-            raise RuntimeError("The imageItem set to a LogScaleIntensity ImageView must be a LogScaleImageItem.")
+class LogScaleIntensity(ComposableItemImageView):
 
-        kwargs["imageItem"] = LogScaleImageItem()
-        super(LogScaleIntensity, self).__init__(*args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        # Composes a new type consisting of any ImageItem types in imageItem_bases with this classes's helper ImageItem
+        # class (LogScaleImageItem)
+        self.imageItem_bases += (LogScaleImageItem,)
+        imageItem = type("DynamicImageItem", tuple(self.imageItem_bases), {})()
+        if "imageItem" in kwargs:
+            del kwargs["imageItem"]
+        super(LogScaleIntensity, self).__init__(imageItem=imageItem, *args, **kwargs)
 
         self.logScale = True
 
@@ -628,8 +642,8 @@ class CatalogView(ImageView):
         self.catalog = catalog
         self.stream = stream
         self.field = field
-        if all(self.catalog, self.stream, self.field):
-            self.xarray = getattr(self.catalog, self.stream)[self.field]
+        if all([self.catalog, self.stream, self.field]):
+            self.xarray = MetaXArray(getattr(self.catalog, self.stream).to_dask()[self.field])
             self.setImage(img=self.xarray, *args, **kwargs)
         else:
             # TODO -- clear the current image
@@ -643,3 +657,62 @@ class CatalogView(ImageView):
         # TODO -- figure out where to put the geometry update
         if QSpace in inspect.getmro(type(self)):
             self.setGeometry(pluginmanager.getPluginByName('xicam.SAXS.calibration', 'SettingsPlugin').plugin_object.AI(field))
+
+
+class ImageItemHistogramOverflowFix(ImageItem):
+    def getHistogram(self, bins='auto', step='auto', targetImageSize=200, targetHistogramSize=500, **kwds):
+        """Returns x and y arrays containing the histogram values for the current image.
+                For an explanation of the return format, see numpy.histogram().
+
+                The *step* argument causes pixels to be skipped when computing the histogram to save time.
+                If *step* is 'auto', then a step is chosen such that the analyzed data has
+                dimensions roughly *targetImageSize* for each axis.
+
+                The *bins* argument and any extra keyword arguments are passed to
+                np.histogram(). If *bins* is 'auto', then a bin number is automatically
+                chosen based on the image characteristics:
+
+                * Integer images will have approximately *targetHistogramSize* bins,
+                  with each bin having an integer width.
+                * All other types will have *targetHistogramSize* bins.
+
+                This method is also used when automatically computing levels.
+                """
+        if self.image is None:
+            return None, None
+        if step == 'auto':
+            step = (int(np.ceil(self.image.shape[0] / targetImageSize)),
+                    int(np.ceil(self.image.shape[1] / targetImageSize)))
+        if np.isscalar(step):
+            step = (step, step)
+        stepData = self.image[::step[0], ::step[1]]
+
+        if bins == 'auto':
+            if stepData.dtype.kind in "ui":
+                mn = stepData.min()
+                mx = stepData.max()
+                # print(f"\n*** mx, mn: {mx}, {mn} ({type(mx)}, {type(mn)})***\n")
+                # PATCH -- explicit subtract with np.int to avoid overflow
+                step = np.ceil(np.subtract(mx, mn, dtype=np.int) / 500.)
+                bins = np.arange(mn, mx + 1.01 * step, step, dtype=np.int)
+                if len(bins) == 0:
+                    bins = [mn, mx]
+            else:
+                bins = 500
+
+        kwds['bins'] = bins
+        stepData = stepData[np.isfinite(stepData)]
+        hist = np.histogram(stepData, **kwds)
+
+        return hist[1][:-1], hist[0]
+
+
+class ImageViewHistogramOverflowFix(ComposableItemImageView):
+    def __init__(self, *args, **kwargs):
+        self.imageItem_bases += (ImageItemHistogramOverflowFix,)
+        # Create a dynamic image item type, composing existing ImageItem classes with this classes's appropriate
+        # ImageItem class (ImageItemHistogramOverflowFix)
+        imageItem = type("DynamicImageItem", tuple(self.imageItem_bases), {})()
+        if "imageItem" in kwargs:
+            del kwargs["imageItem"]
+        super(ImageViewHistogramOverflowFix, self).__init__(imageItem=imageItem, *args, **kwargs)

--- a/xicam/gui/widgets/imageviewmixins.py
+++ b/xicam/gui/widgets/imageviewmixins.py
@@ -600,7 +600,7 @@ class LogScaleIntensity(ImageView):
         self.logIntensityButton.setChecked(value)
 
 
-class CatalogView(ImageView):
+class XArrayView(ImageView):
     def quickMinMax(self, data):
         """
         Estimate the min/max values of *data* by subsampling. MODIFIED TO USE THE 99TH PERCENTILE instead of max.
@@ -611,3 +611,18 @@ class CatalogView(ImageView):
         sl = slice(None, None, max(1, int(data.size // 1e6)))
         data = np.asarray(data[sl])
         return (np.nanmin(data), np.nanpercentile(np.where(data < np.nanmax(data), data, np.nanmin(data)), 99))
+
+
+class CatalogView(ImageView):
+    def setCatalog(self, catalog, stream, field, *args, **kwargs):
+        self.catalog = catalog
+        self.stream = stream
+        self.field = field
+        self.xarray = getattr(self.catalog, self.stream)[self.field]
+        self.setImage(img=self.xarray, *args, **kwargs)
+
+    def streamChanged(self, stream):
+        self.setCatalog(self.catalog, stream, self.field)
+
+    def fieldChanged(self, field):
+        self.setCatalog(self.catalog, self.stream, field)

--- a/xicam/gui/widgets/linearworkfloweditor.py
+++ b/xicam/gui/widgets/linearworkfloweditor.py
@@ -30,7 +30,7 @@ class WorkflowEditor(QSplitter):
 
         self.workflowview.sigShowParameter.connect(lambda parameter: self.setParameters(parameter))
 
-        workflow.attach(partial(self.sigWorkflowChanged.emit, workflow))
+        workflow.attach(self.sigWorkflowChanged.emit)
 
     def setParameters(self, parameter: Parameter):
 

--- a/xicam/gui/windows/mainwindow.py
+++ b/xicam/gui/windows/mainwindow.py
@@ -308,7 +308,12 @@ class pluginModeWidget(QToolBar):
             self._showNodes(nodes, direction)
             # self.fadeOut(callback=partial(self.mkButtons, names=names, callback=self.showStages), distance=0)
 
-        elif isinstance(node.object, (dict, PluginInfo.PluginInfo, EntryPointPluginInfo)):
+        elif isinstance(node.object, dict):
+            nodes = node.children
+            if len(nodes) > 1:
+                self._showNodes(nodes, direction)
+
+        elif isinstance(node.object, (PluginInfo.PluginInfo, EntryPointPluginInfo)):
             nodes = node.children
             if len(nodes) > 1:
                 self._showNodes(nodes, direction)

--- a/xicam/gui/windows/mainwindow.py
+++ b/xicam/gui/windows/mainwindow.py
@@ -291,7 +291,8 @@ class pluginModeWidget(QToolBar):
 
         elif isinstance(node.object, (dict, PluginInfo.PluginInfo, EntryPointPluginInfo)):
             nodes = node.children
-            self._showNodes(nodes, direction)
+            if len(nodes) > 1:
+                self._showNodes(nodes, direction)
             self.sigSetGUIPlugin.emit(node.object.plugin_object)
             self.setStage(node.object.plugin_object.stage)
 


### PR DESCRIPTION
Sync changes with master to keep up to date.

Add to imageviewmixins to allow for composable ImageViews. The ImageViewHistogramOverflowFix avoids a RunTimeWarning issued by numpy during a subtraction overflow in pyqtgraph's ImageItem.getHistorgram(). This can be composed with the LogScaleIntensity mixin.