### PR TITLE
FIX: accept args as input to splash screen rather than global state

### DIFF
--- a/xicam/gui/windows/splash.py
+++ b/xicam/gui/windows/splash.py
@@ -6,14 +6,15 @@ from qtpy.QtGui import QMovie, QPixmap
 from qtpy.QtWidgets import QSplashScreen, QApplication, QMainWindow
 
 from xicam.gui import static
-from xicam.args import args
 
 
 class XicamSplashScreen(QSplashScreen):
     minsplashtime = 3000
 
     def __init__(self, mainwindow: Callable[[], QMainWindow] = None,
-                 f: int = Qt.WindowStaysOnTopHint | Qt.SplashScreen):
+                 f: int = Qt.WindowStaysOnTopHint | Qt.SplashScreen,
+                 *,
+                 args):
         """
         A QSplashScreen customized to display an animated gif. The splash triggers launch when clicked.
 


### PR DESCRIPTION
Follow on to https://github.com/synchrotrons/Xi-cam/pull/53