### PR TITLE
Add ability to talk to remote Intake Server.

### DIFF
--- a/xicam/gui/bluesky/search.py
+++ b/xicam/gui/bluesky/search.py
@@ -131,8 +131,9 @@ class SearchState(ConfigurableQObject):
     def flatten_remote_catalogs(self, catalog):
         from intake.catalog.base import Catalog
         cat_dict = {}
-        try:
-            for name in catalog:
+
+        for name in catalog:
+            try:
                 from intake.catalog.base import RemoteCatalog
                 sub_cat = catalog[name]
                 # @TODO remote catalogs are one level too high. This check is
@@ -147,12 +148,12 @@ class SearchState(ConfigurableQObject):
                         cat_dict[name] = sub_cat[name]
                 else:
                     cat_dict[name] = sub_cat
+            except Exception as e:
+                log.error(e)
+                msg.showMessage("Unable to query top level catalogs: ", str(e))
 
-            return Catalog.from_dict(cat_dict)
-        except Exception as e:
-            log.error(e)
-            msg.showMessage("Unable to query top level catalogs: ", str(e))
-            return None
+        return Catalog.from_dict(cat_dict)
+
 
     def request_reload(self):
         self._results_catalog.force_reload()

--- a/xicam/gui/bluesky/search.py
+++ b/xicam/gui/bluesky/search.py
@@ -35,7 +35,7 @@ from xicam.core import msg
 from .utils import ConfigurableQObject
 from .top_utils import load_config, Callable
 from xicam.core import msg
-from xicam.core.threads import invoke_in_main_thread
+from xicam.core import threads
 
 MAX_SEARCH_RESULTS = 100  # TODO Use fetchMore instead of a hard limit.
 log = logging.getLogger('bluesky_browser')
@@ -52,6 +52,14 @@ QLineEdit {
 RELOAD_INTERVAL = 11
 _validate = functools.partial(jsonschema.validate, types={'array': (list, tuple)})
 
+def timeit(f):
+    def wrap(*args):
+        time1 = time.time()
+        ret = f(*args)
+        time2 = time.time()
+        print('{:s} function took {:.3f} ms'.format(f.__name__, (time2-time1)*1000.0))
+        return ret
+    return wrap
 
 def default_search_result_row(entry):
     start = entry.metadata['start']
@@ -94,12 +102,14 @@ class SearchState(ConfigurableQObject):
         self.set_selected_catalog(0)
         self.query_queue = queue.Queue()
         self.show_results_event = threading.Event()
+        self.show_results_event.set()
         self.reload_event = threading.Event()
         search_state = self
 
         super().__init__()
 
-        self.new_results_catalog.connect(self.show_results)
+        self.last_results_thread = None
+        self.new_results_catalog.connect(self.start_show_results)
 
         class ReloadThread(QThread):
             def run(self):
@@ -125,11 +135,19 @@ class SearchState(ConfigurableQObject):
                     try:
                         search_state.process_queries()
                     except Exception as e:
-                        log.error(e)
+                        msg.logError(e)
                         msg.showMessage("Unable to query: ", str(e))
 
         self.process_queries_thread = ProcessQueriesThread()
         self.process_queries_thread.start()
+
+    def start_show_results(self):
+        if not self.show_results_event.is_set():
+            if self.last_results_thread:
+                self.last_results_thread.requestInterruption()
+            self.show_results_event.wait()
+        self.last_results_thread = threads.QThreadFuture(self.show_results)
+        self.last_results_thread.start()
 
     def flatten_remote_catalogs(self, catalog):
         from intake.catalog.base import Catalog
@@ -227,6 +245,7 @@ class SearchState(ConfigurableQObject):
     def process_queries(self):
         # If there is a backlog, process only the newer query.
         block = True
+        
         while True:
             try:
                 query = self.query_queue.get_nowait()
@@ -253,6 +272,10 @@ class SearchState(ConfigurableQObject):
             msg.hideBusy()
 
     def search(self):
+        self._new_uids_queue = queue.Queue(maxsize=MAX_SEARCH_RESULTS)
+        if self.last_results_thread and not self.show_results_event.is_set():
+            self.last_results_thread.requestInterruption()
+            self.last_results_thread.wait()
         self.search_results_model.clear()
         self.search_results_model.selected_rows.clear()
         self.open_uids.clear()
@@ -266,6 +289,11 @@ class SearchState(ConfigurableQObject):
         query.update(**self.search_results_model.custom_query)
         self.query_queue.put(query)
 
+    @timeit
+    def get_run_by_uid(self, uid):
+        return self._results_catalog[uid]
+
+
     def show_results(self):
         header_labels_set = False
         self.show_results_event.clear()
@@ -277,7 +305,7 @@ class SearchState(ConfigurableQObject):
             while not self._new_uids_queue.empty():
                 counter += 1
                 new_uid = self._new_uids_queue.get()
-                entry = self._results_catalog[new_uid]
+                entry = self.get_run_by_uid(new_uid)
                 row = []
                 try:
                     row_data = self.apply_search_result_row(entry)
@@ -285,20 +313,23 @@ class SearchState(ConfigurableQObject):
                     continue
                 if not header_labels_set:
                     # Set header labels just once.
-                    self.search_results_model.setHorizontalHeaderLabels(list(row_data))
+                    threads.invoke_in_main_thread(self.search_results_model.setHorizontalHeaderLabels, list(row_data))
                     header_labels_set = True
                 for value in row_data.values():
                     item = QStandardItem()
                     item.setData(value, Qt.DisplayRole)
                     item.setData(new_uid, Qt.UserRole)
                     row.append(item)
-                self.search_results_model.appendRow(row)
+                if QThread.currentThread().isInterruptionRequested():
+                    self.show_results_event.set()
+                    return
+                threads.invoke_in_main_thread(self.search_results_model.appendRow, row)
+
             if counter:
                 self.sig_update_header.emit()
                 duration = time.monotonic() - t0
                 log.debug("Displayed %d new results (%.3f s).", counter, duration)
             self.show_results_event.set()
-            msg.hideBusy()
         except Exception as e:
             msg.showMessage("Error displaying runs")
             msg.logError(e)
@@ -556,6 +587,7 @@ class SearchWidget(QWidget):
                 # action.triggered.connect(lambda triggered, logicalIndex=i: self.unhide_column(header, logicalIndex))
 
         menu.exec_(header.mapToGlobal(position))
+
 
 
 class SkipRow(Exception):

--- a/xicam/gui/bluesky/summary.py
+++ b/xicam/gui/bluesky/summary.py
@@ -50,7 +50,6 @@ class SummaryWidget(QWidget):
 
     def call_entry(self, entries):
         entry, = entries
-        run = entry()
         return entry()
 
     def set_entries(self, entries):


### PR DESCRIPTION
In order to successfully talk to an Intake Server, changes need to be made to the catalog browsing. Normally, the 

`from datbroker import Catalog`

will provide a top level catalog where the second level is a list of catalogs that are themselves BlueskyRun instances.

However, when you configure intake to point to an Intake Server, the server is represented as a catalog one level higher than that.

This has the feeling of a temporary fix. We probably want a UI that can let the user select their own "top level" catalogs from a tree control of some sort, since there is no rule that says that any given level is a "top level". 

This PR is also looking to make the interactivity a little better by displaying progress and business to users as searches are made.